### PR TITLE
Feature/component update I

### DIFF
--- a/app/components/discord.tsx
+++ b/app/components/discord.tsx
@@ -22,7 +22,20 @@ export function DiscordStatus() {
     }, [status])
 
     if (loading || !status?.discord_user) {
-        return <div className="flex items-center space-x-3"></div>
+        return (
+            <div className="ml-6">
+                <div>
+                    <span className="webtree">└──</span>
+                    <span className="websub">username/</span>
+                    <span className="webcontent">...</span>
+                </div>
+                <div>
+                    <span className="webtree">└──</span>
+                    <span className="websub">activity/</span>
+                    <span className="webcontent">...</span>
+                </div>
+            </div>
+        )
     }
 
     const statusColor =

--- a/app/components/ukstrava.tsx
+++ b/app/components/ukstrava.tsx
@@ -93,7 +93,30 @@ const Activities: React.FC<ActivitiesProps> = React.memo(
         const latestActivity = useMemo(() => activities[0], [activities])
 
         if (isLoading) {
-            return <div></div>
+            return (
+                <div className="block ml-6">
+                    <div>
+                        <span className="webtree">└──</span>
+                        <span className="websub">title/</span>
+                        <span className="webcontent">....</span>
+                    </div>
+                    <div>
+                        <span className="webtree">└──</span>
+                        <span className="websub">date/</span>
+                        <span className="webcontent">...</span>
+                    </div>
+                    <div>
+                        <span className="webtree">└──</span>
+                        <span className="websub">time/</span>
+                        <span className="webcontent">.... </span>
+                    </div>
+                    <div>
+                        <span className="webtree">└──</span>
+                        <span className="websub">distance/</span>
+                        <span className="webcontent">.... </span>
+                    </div>
+                </div>
+            )
         }
 
         if (!activities.length) return null


### PR DESCRIPTION
This pull request improves the loading states for both the Discord and Strava activity components by providing more informative placeholder UI elements while data is being fetched. It also makes a minor UI adjustment in the Discord activity display.

**Loading state UI improvements:**

* Updated the loading state in `DiscordStatus` (`app/components/discord.tsx`) to display placeholder elements for username and activity, improving user experience while waiting for data.
* Enhanced the loading state in `Activities` (`app/components/ukstrava.tsx`) to show placeholders for title, date, time, and distance, making the UI more informative during data fetch.

**UI adjustment:**

* Commented out the " @ " separator in the Discord activity state display and replaced it with a dash for improved readability. (`app/components/discord.tsx`)