### PR TITLE
feat: add publish and draft post

### DIFF
--- a/app/api/posts/[slug]/route.ts
+++ b/app/api/posts/[slug]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPostBySlug, updatePost } from 'app/lib/posts';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  try {
+    const { slug } = await params;
+    const post = await getPostBySlug(slug);
+    if (!post) {
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+    }
+    return NextResponse.json(post);
+  } catch (error) {
+    console.error('Error fetching post:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to fetch post',
+        details: (error as Error).message,
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
+  try {
+    const { slug } = await params;
+    const body = await request.json();
+    const { title, content, tags, summary, author, status } = body;
+
+    if (!title || !content) {
+      return NextResponse.json(
+        { error: 'Title and content are required' },
+        { status: 400 }
+      );
+    }
+
+    const updatedPost = await updatePost(slug, {
+      title,
+      content,
+      tags,
+      summary,
+      author,
+      status,
+    });
+
+    if (!updatedPost) {
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, post: updatedPost });
+  } catch (error) {
+    console.error('Error updating post:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to update post',
+        details: (error as Error).message,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,27 +1,46 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createPost } from 'app/lib/posts'
+import { createPost, getAllPosts } from 'app/lib/posts'
+
+export async function GET(request: NextRequest) {
+    try {
+        const posts = await getAllPosts();
+        return NextResponse.json(posts);
+    } catch (error) {
+        console.error('Error fetching posts:', error);
+        return NextResponse.json(
+            {
+                error: 'Failed to fetch posts',
+                details: (error as Error).message,
+            },
+            { status: 500 }
+        )
+    }
+}
 
 export async function POST(request: NextRequest) {
     try {
         const body = await request.json()
 
         // Simple validation
-        if (!body.title || !body.slug || !body.content) {
+        if (!body.title || !body.content) {
             return NextResponse.json(
-                { error: 'Title, slug, and content are required fields' },
+                { error: 'Title and content are required fields' },
                 { status: 400 }
             )
         }
 
+        const slug = body.slug || body.title.toLowerCase().replace(/\s+/g, '-');
+
         // Create a new post
         const newPost = await createPost({
             title: body.title,
-            slug: body.slug,
+            slug: slug,
             content: body.content,
             summary: body.summary || '',
             publishedAt: body.publishedAt || new Date().toISOString(),
             tags: body.tags || [],
             author: body.author || 'qyzh',
+            status: body.status || 'draft',
         })
 
         return NextResponse.json(

--- a/app/components/posts.tsx
+++ b/app/components/posts.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { getAllPosts } from 'app/lib/posts'
+import { getAllPublishedPosts } from 'app/lib/posts'
 
 interface BlogPost {
     _id: string
@@ -33,7 +33,7 @@ const PostCard = ({ post }: PostCardProps) => {
 }
 
 export async function BlogPosts() {
-    const allBlogs = await getAllPosts()
+    const allBlogs = await getAllPublishedPosts()
 
     return (
         <div role="list" aria-label="Blog posts" className="group">

--- a/app/lib/posts.ts
+++ b/app/lib/posts.ts
@@ -10,6 +10,7 @@ export interface Post {
     updatedAt?: string
     tags?: string[]
     author?: string
+    status: 'draft' | 'published'
 }
 
 async function getDb() {
@@ -22,6 +23,23 @@ export async function getAllPosts(): Promise<Post[]> {
     const posts = await db
         .collection('dirpost')
         .find({})
+        .sort({ publishedAt: -1 })
+        .toArray()
+
+    return posts.map(
+        (post) =>
+            ({
+                ...post,
+                _id: post._id.toString(),
+            }) as Post
+    )
+}
+
+export async function getAllPublishedPosts(): Promise<Post[]> {
+    const db = await getDb()
+    const posts = await db
+        .collection('dirpost')
+        .find({ status: 'published' })
         .sort({ publishedAt: -1 })
         .toArray()
 
@@ -58,6 +76,7 @@ export async function createPost(post: Omit<Post, '_id'>): Promise<Post> {
         ...post,
         publishedAt: post.publishedAt || now,
         updatedAt: now,
+        status: post.status || 'draft',
     }
 
     const result = await db.collection('dirpost').insertOne(postToInsert)


### PR DESCRIPTION
This pull request introduces new API endpoints for fetching and updating individual blog posts, improves the posts API to better handle status and slug creation, and updates the codebase to distinguish between published and draft posts. The changes also add a `status` field to the `Post` model and ensure only published posts are displayed in the blog post list.

**API Enhancements:**

* Added a new route `app/api/posts/[slug]/route.ts` to support fetching (`GET`) and updating (`PUT`) individual posts by slug, including error handling for missing or failed operations. ([app/api/posts/[slug]/route.tsR1-R61](diffhunk://#diff-c8883cba09b7363ea19ce69cbca1af2a510114fa73fc1c2a5e7bc06cb03397c7R1-R61))
* Updated the main posts API (`app/api/posts/route.ts`) to support fetching all posts (`GET`), improved validation for required fields, and auto-generates slugs if not provided.

**Data Model and Query Improvements:**

* Added a `status` field (`'draft' | 'published'`) to the `Post` interface, and ensured the `status` is set when creating posts. [[1]](diffhunk://#diff-e0d130593a72d881fed8ab93b4c88c4d41b875a9c0ee6133bfb307522d3ca794R13) [[2]](diffhunk://#diff-e0d130593a72d881fed8ab93b4c88c4d41b875a9c0ee6133bfb307522d3ca794R79)
* Introduced a new function `getAllPublishedPosts` in `app/lib/posts.ts` to fetch only published posts, and updated the blog post list component to use this function instead of fetching all posts. [[1]](diffhunk://#diff-e0d130593a72d881fed8ab93b4c88c4d41b875a9c0ee6133bfb307522d3ca794R38-R54) [[2]](diffhunk://#diff-0e88e4f8aa269c374b38ecd19c41262467a171e8562e52e2f648f2a8da89122dL2-R2) [[3]](diffhunk://#diff-0e88e4f8aa269c374b38ecd19c41262467a171e8562e52e2f648f2a8da89122dL36-R36)